### PR TITLE
fix error handling

### DIFF
--- a/src/main/java/brcomkassin/blockLimiter/commands/BlockLimiterCommand.java
+++ b/src/main/java/brcomkassin/blockLimiter/commands/BlockLimiterCommand.java
@@ -35,35 +35,30 @@ public class BlockLimiterCommand implements TabExecutor {
             return true;
         }
 
-        try {
-            switch (args[0].toLowerCase()) {
-                case "criar":
-                    handleCreateGroup(player, args);
-                    break;
+        switch (args[0].toLowerCase()) {
+            case "criar":
+                handleCreateGroup(player, args);
+                break;
 
-                case "adicionar":
-                    handleAddToGroup(player, args);
-                    break;
+            case "adicionar":
+                handleAddToGroup(player, args);
+                break;
 
-                case "deletar":
-                    handleDeleteGroup(player, args);
-                    break;
+            case "deletar":
+                handleDeleteGroup(player, args);
+                break;
 
-                case "limite":
-                    handleUpdateLimit(player, args);
-                    break;
+            case "limite":
+                handleUpdateLimit(player, args);
+                break;
 
-                case "remover":
-                    handleRemoveFromGroup(player, args);
-                    break;
+            case "remover":
+                handleRemoveFromGroup(player, args);
+                break;
 
-                default:
-                    showHelp(player);
-                    break;
-            }
-        } catch (SQLException e) {
-            Message.Chat.send(player, ConfigManager.getMessage("commands.errors.group-not-found", 
-                "group", args[1]));
+            default:
+                showHelp(player);
+                break;
         }
         return true;
     }
@@ -138,8 +133,21 @@ public class BlockLimiterCommand implements TabExecutor {
         }
 
         String groupName = args[1];
-        BlockLimiter.addMaterialToGroup(groupName, material);
-        Message.Chat.send(player, ConfigManager.getMessage("commands.item-added"));
+        try {
+            BlockLimiter.addMaterialToGroup(groupName, material);
+            Message.Chat.send(player, ConfigManager.getMessage("commands.item-added"));
+        } catch (SQLException e) {
+            if (e.getMessage().contains("já está no grupo")) {
+                Message.Chat.send(player, ConfigManager.getMessage("commands.errors.item-already-in-group",
+                    "group", e.getMessage().split("grupo ")[1]));
+            } else if (e.getMessage().contains("Grupo não encontrado")) {
+                Message.Chat.send(player, ConfigManager.getMessage("commands.errors.group-not-found",
+                    "group", groupName));
+            } else {
+                Message.Chat.send(player, ConfigManager.getMessage("commands.errors.database-error"));
+                e.printStackTrace();
+            }
+        }
     }
 
     private void handleDeleteGroup(Player player, String[] args) throws SQLException {


### PR DESCRIPTION
This pull request includes several changes to the `BlockLimiterCommand` class to improve error handling and remove unnecessary try-catch blocks. The most important changes include adding specific error messages for different SQLException scenarios and removing redundant exception handling.

Error handling improvements:

* [`src/main/java/brcomkassin/blockLimiter/commands/BlockLimiterCommand.java`](diffhunk://#diff-ed166cc242eef9f00fd7c9ce75e4462aba585ea6c35294e6da0f424235d3cf1aR136-R150): Added specific error messages for when an item is already in a group, when a group is not found, and for general database errors in the `handleAddToGroup` method.

Code simplification:

* [`src/main/java/brcomkassin/blockLimiter/commands/BlockLimiterCommand.java`](diffhunk://#diff-ed166cc242eef9f00fd7c9ce75e4462aba585ea6c35294e6da0f424235d3cf1aL38): Removed the try-catch block for SQLException in the `onCommand` method to simplify the code and avoid redundant exception handling. [[1]](diffhunk://#diff-ed166cc242eef9f00fd7c9ce75e4462aba585ea6c35294e6da0f424235d3cf1aL38) [[2]](diffhunk://#diff-ed166cc242eef9f00fd7c9ce75e4462aba585ea6c35294e6da0f424235d3cf1aL64-L67)