### PR TITLE
improving block placement recording functionality and updating the maven configuration.

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -18,8 +18,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/brcomkassin/blockLimiter/limiter/BlockLimiter.java
+++ b/src/main/java/brcomkassin/blockLimiter/limiter/BlockLimiter.java
@@ -111,6 +111,10 @@ public class BlockLimiter {
         BlockGroup group = findGroupForMaterial(material);
         if (group == null) return;
 
+        if (isBlockRegistered(location)) {
+            removeBlockFromDatabase(location);
+        }
+
         String query = "INSERT INTO placed_blocks (player_uuid, group_id, item_id, world, x, y, z) VALUES (?, ?, ?, ?, ?, ?, ?)";
         try (PreparedStatement ps = SQLiteManager.getConnection().prepareStatement(query)) {
             ps.setString(1, player.getUniqueId().toString());

--- a/src/main/java/brcomkassin/blockLimiter/limiter/BlockLimiter.java
+++ b/src/main/java/brcomkassin/blockLimiter/limiter/BlockLimiter.java
@@ -111,9 +111,7 @@ public class BlockLimiter {
         BlockGroup group = findGroupForMaterial(material);
         if (group == null) return;
 
-        if (isBlockRegistered(location)) {
-            removeBlockFromDatabase(location);
-        }
+        removeBlockFromDatabase(location);
 
         String query = "INSERT INTO placed_blocks (player_uuid, group_id, item_id, world, x, y, z) VALUES (?, ?, ?, ?, ?, ?, ?)";
         try (PreparedStatement ps = SQLiteManager.getConnection().prepareStatement(query)) {
@@ -435,9 +433,7 @@ public class BlockLimiter {
     }
 
     public static void removeBlockIfExists(Location location) {
-        if (isBlockRegistered(location)) {
-            removeBlockFromDatabase(location);
-        }
+        removeBlockFromDatabase(location);
     }
 
     public static boolean isBlockRegistered(Location location) {


### PR DESCRIPTION
This pull request includes several changes aimed at improving the block placement recording functionality and updating the Maven configuration. The most important changes include modifying the Maven compiler plugin configuration and enhancing the block placement logic to handle delayed processing.

### Maven Configuration Updates:
* [`dependency-reduced-pom.xml`](diffhunk://#diff-7182001772a851ff92a09525a7b6d383ea0315d75612d43e3272a78adb3058c1L21-R21): Changed the Maven compiler plugin configuration to use the `<release>` tag instead of `<source>` and `<target>` tags for specifying the Java version.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L27-R27): Similarly updated the Maven compiler plugin configuration to use the `<release>` tag.

### Block Placement Logic Enhancements:
* [`src/main/java/brcomkassin/blockLimiter/limiter/BlockLimiter.java`](diffhunk://#diff-06e9b06fe520f7d0e3b4b48ef57c2c8b6cf091881ae1ff995d1282c6fd1a40a1R114-R117): Added logic to check if a block is already registered at a location and remove it from the database before recording a new placement.
* [`src/main/java/brcomkassin/blockLimiter/listeners/BlockPlaceListener.java`](diffhunk://#diff-1ca16d8c5bbae02c2a23b9faedf60c0ecfea793406bb789a8ebc79e1b374479aR44-R61): Introduced an `AtomicBoolean` to manage delayed block placement processing with retries at different intervals (2, 6, and 10 ticks).
* [`src/main/java/brcomkassin/blockLimiter/listeners/BlockPlaceListener.java`](diffhunk://#diff-1ca16d8c5bbae02c2a23b9faedf60c0ecfea793406bb789a8ebc79e1b374479aR4): Imported `AtomicBoolean` to support the new delayed processing logic.