### PR TITLE
optimize multiblock breaking and some other stuff

### DIFF
--- a/src/main/java/brcomkassin/blockLimiter/limiter/BlockLimiter.java
+++ b/src/main/java/brcomkassin/blockLimiter/limiter/BlockLimiter.java
@@ -289,17 +289,55 @@ public class BlockLimiter {
         BlockGroup group = findGroupForMaterial(material);
         if (group == null) return;
 
-        String deleteQuery = "DELETE FROM placed_blocks WHERE player_uuid = ? AND world = ? AND x = ? AND y = ? AND z = ?";
-        try (PreparedStatement ps = SQLiteManager.getConnection().prepareStatement(deleteQuery)) {
-            ps.setString(1, player.getUniqueId().toString());
-            ps.setString(2, location.getWorld().getName());
-            ps.setInt(3, location.getBlockX());
-            ps.setInt(4, location.getBlockY());
-            ps.setInt(5, location.getBlockZ());
-            ps.executeUpdate();
+        String query = """
+            WITH closest_block AS (
+                SELECT world, x, y, z 
+                FROM placed_blocks 
+                WHERE world = ? 
+                AND x BETWEEN ? AND ? 
+                AND y BETWEEN ? AND ? 
+                AND z BETWEEN ? AND ? 
+                AND item_id = ?
+                ORDER BY (
+                    POW(x - ?, 2) + 
+                    POW(y - ?, 2) + 
+                    POW(z - ?, 2)
+                ) ASC 
+                LIMIT 1
+            )
+            DELETE FROM placed_blocks 
+            WHERE EXISTS (
+                SELECT 1 FROM closest_block 
+                WHERE placed_blocks.world = closest_block.world 
+                AND placed_blocks.x = closest_block.x 
+                AND placed_blocks.y = closest_block.y 
+                AND placed_blocks.z = closest_block.z
+            )
+            RETURNING world, x, y, z
+        """;
+
+        boolean removed;
+        try (PreparedStatement ps = SQLiteManager.getConnection().prepareStatement(query)) {
+            ps.setString(1, location.getWorld().getName());
+            ps.setInt(2, location.getBlockX() - 3);
+            ps.setInt(3, location.getBlockX() + 3);
+            ps.setInt(4, location.getBlockY() - 3);
+            ps.setInt(5, location.getBlockY() + 3);
+            ps.setInt(6, location.getBlockZ() - 3);
+            ps.setInt(7, location.getBlockZ() + 3);
+            ps.setString(8, material.name());
+            ps.setInt(9, location.getBlockX());
+            ps.setInt(10, location.getBlockY());
+            ps.setInt(11, location.getBlockZ());
+
+            try (ResultSet rs = ps.executeQuery()) {
+                removed = rs.next();
+            }
         }
 
-        recordBlockHistory(player, group.getGroupId(), material, location, "BREAK");
+        if (removed) {
+            recordBlockHistory(player, group.getGroupId(), material, location, "BREAK");
+        }
     }
 
     public static int getBlockLimit(String groupId) throws SQLException {
@@ -432,10 +470,6 @@ public class BlockLimiter {
         LOGGER.log(Level.INFO, "Carregados {0} grupos com suas configura\u00e7\u00f5es", blockGroups.size());
     }
 
-    public static void removeBlockIfExists(Location location) {
-        removeBlockFromDatabase(location);
-    }
-
     public static boolean isBlockRegistered(Location location) {
         String query = "SELECT COUNT(*) as count FROM placed_blocks WHERE world = ? AND x = ? AND y = ? AND z = ?";
         try (PreparedStatement ps = SQLiteManager.getConnection().prepareStatement(query)) {
@@ -500,13 +534,6 @@ public class BlockLimiter {
 
     public static boolean isBlockRegistered(Location location, Material material) {
         return findRegisteredBlock(location, material) != null;
-    }
-
-    public static void removeBlockIfExists(Location location, Material material) {
-        Location registeredLocation = findRegisteredBlock(location, material);
-        if (registeredLocation != null) {
-            removeBlockFromDatabase(registeredLocation);
-        }
     }
 
 }

--- a/src/main/java/brcomkassin/blockLimiter/listeners/PacketBlockBreakListener.java
+++ b/src/main/java/brcomkassin/blockLimiter/listeners/PacketBlockBreakListener.java
@@ -56,10 +56,8 @@ public class PacketBlockBreakListener {
                                 if (processed.get()) return;
                                 Material currentType = block.getType();
                                 if (currentType == Material.AIR) {
-                                    if (BlockLimiter.isBlockRegistered(location, originalType)) {
-                                        BlockLimiter.recordBlockBreak(player, originalType, location);
-                                        processed.set(true);
-                                    }
+                                    BlockLimiter.recordBlockBreak(player, originalType, location);
+                                    processed.set(true);
                                 }
                             } catch (SQLException e) {
                                 LOGGER.log(Level.SEVERE, 
@@ -67,11 +65,10 @@ public class PacketBlockBreakListener {
                             }  
                         }, delay);
                     }
-
-            } catch (FieldAccessException | IllegalArgumentException e) {
-                LOGGER.log(Level.SEVERE, "Erro ao processar pacote de quebra de bloco", e);
+                } catch (FieldAccessException | IllegalArgumentException e) {
+                    LOGGER.log(Level.SEVERE, "Erro ao processar pacote de quebra de bloco", e);
+                }
             }
-        }
-    });
-}
+        });
+    }
 } 

--- a/src/main/java/brcomkassin/blockLimiter/listeners/PacketBlockInteractListener.java
+++ b/src/main/java/brcomkassin/blockLimiter/listeners/PacketBlockInteractListener.java
@@ -1,6 +1,7 @@
 package brcomkassin.blockLimiter.listeners;
 
 import java.lang.reflect.InvocationTargetException;
+import java.sql.SQLException;
 import java.util.logging.Level;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -104,6 +105,7 @@ public class PacketBlockInteractListener {
 
     private static void scheduleBlockChecks(Block block, Player player, Location blockLocation) {
         AtomicBoolean processed = new AtomicBoolean(false);
+        Material originalType = block.getType();
 
         for (int delay : new int[]{2, 6, 10}) {
             org.bukkit.Bukkit.getScheduler().runTaskLater(BlockLimiterPlugin.getInstance(), () -> {
@@ -111,13 +113,11 @@ public class PacketBlockInteractListener {
                     if (processed.get()) return;
 
                     Material currentType = block.getType();
-                    boolean isRegistered = BlockLimiter.isBlockRegistered(blockLocation);
-                    
-                    if (currentType == Material.AIR && isRegistered) {
-                        BlockLimiter.removeBlockIfExists(blockLocation);
+                    if (currentType == Material.AIR) {
+                        BlockLimiter.recordBlockBreak(player, originalType, blockLocation);
                         processed.set(true);
                     }
-                } catch (Exception e) {
+                } catch (SQLException e) {
                     LOGGER.log(Level.SEVERE, 
                         "Erro ao processar verificação do bloco para o jogador " + player.getName(), e);
                 }


### PR DESCRIPTION
This pull request includes significant changes to the `BlockLimiter` functionality, primarily focusing on improving the block break recording process and simplifying the codebase by removing redundant methods. The most important changes are:

Improvements to block break recording:

* [`src/main/java/brcomkassin/blockLimiter/limiter/BlockLimiter.java`](diffhunk://#diff-06e9b06fe520f7d0e3b4b48ef57c2c8b6cf091881ae1ff995d1282c6fd1a40a1L292-R341): Updated the `recordBlockBreak` method to use a more efficient query for finding and removing the closest block within a certain range, and added a check to confirm the block was removed before recording the block history.

Codebase simplification:

* [`src/main/java/brcomkassin/blockLimiter/limiter/BlockLimiter.java`](diffhunk://#diff-06e9b06fe520f7d0e3b4b48ef57c2c8b6cf091881ae1ff995d1282c6fd1a40a1L435-L438): Removed the `removeBlockIfExists` method and its overloaded variant, as they are no longer needed. [[1]](diffhunk://#diff-06e9b06fe520f7d0e3b4b48ef57c2c8b6cf091881ae1ff995d1282c6fd1a40a1L435-L438) [[2]](diffhunk://#diff-06e9b06fe520f7d0e3b4b48ef57c2c8b6cf091881ae1ff995d1282c6fd1a40a1L505-L511)

Bug fix in packet handling:

* [`src/main/java/brcomkassin/blockLimiter/listeners/PacketBlockBreakListener.java`](diffhunk://#diff-c31b2749b4c25d02c83b8153cbd0256b3de45eefd659df9a67feac82da7b8a3cL59-L70): Fixed a bug where the block break was recorded even if the block was not registered.

Additional improvements:

* [`src/main/java/brcomkassin/blockLimiter/listeners/PacketBlockInteractListener.java`](diffhunk://#diff-c01c7ef9c9bbc43790471c44dafab3d130f98201f8f0b0208b46997e8a5e2607R4): Added a missing import for `SQLException` and updated the `scheduleBlockChecks` method to use the `recordBlockBreak` method directly, removing the check for block registration. [[1]](diffhunk://#diff-c01c7ef9c9bbc43790471c44dafab3d130f98201f8f0b0208b46997e8a5e2607R4) [[2]](diffhunk://#diff-c01c7ef9c9bbc43790471c44dafab3d130f98201f8f0b0208b46997e8a5e2607R108-R120)